### PR TITLE
Change to URL of the GDS distribution

### DIFF
--- a/simple/node.sh
+++ b/simple/node.sh
@@ -90,8 +90,8 @@ mkdir -p /etc/neo4j/downloads
 
 if [[ $graphDataScienceVersion != None ]]; then
   echo Installing Graph Data Science...
-  curl https://s3-eu-west-1.amazonaws.com/com.neo4j.graphalgorithms.dist/graph-data-science/neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip
-  unzip neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip
+  curl https://graphdatascience.ninja/neo4j-graph-data-science-${graphDataScienceVersion}.zip -o neo4j-graph-data-science-${graphDataScienceVersion}.zip
+  unzip neo4j-graph-data-science-${graphDataScienceVersion}.zip
   mv neo4j-graph-data-science-${graphDataScienceVersion}.jar /var/lib/neo4j/plugins
 fi
 


### PR DESCRIPTION
In order to comply with the sanctions against Russia,
we are moving the GDS artifacts to a new bucket that sits
behind Cloudflare and Route53 with a new domain.

Unfortunately, we cannot configure redirects from the current S3
bucket, because redirects only apply if the bucket is configured
to use static website hosting, but we used the direct object URLs.
Regardless of bucket configuration, using the direct object URL
on a public object will not issue a redirect.